### PR TITLE
Add middleware for HTTP Basic authentication.

### DIFF
--- a/Barista.xcodeproj/project.pbxproj
+++ b/Barista.xcodeproj/project.pbxproj
@@ -58,6 +58,10 @@
 		1E5DFA7C172F81F300FB6CD1 /* BARMustacheTemplateRenderer.m in Sources */ = {isa = PBXBuildFile; fileRef = 1E5DFA7A172F81F300FB6CD1 /* BARMustacheTemplateRenderer.m */; };
 		1E5DFA7F172F82EA00FB6CD1 /* BARTemplateRenderer.h in Headers */ = {isa = PBXBuildFile; fileRef = 1E5DFA7D172F82EA00FB6CD1 /* BARTemplateRenderer.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		1E5DFA80172F82EA00FB6CD1 /* BARTemplateRenderer.m in Sources */ = {isa = PBXBuildFile; fileRef = 1E5DFA7E172F82EA00FB6CD1 /* BARTemplateRenderer.m */; };
+		A998249117CAA39200646828 /* BARBasicAuthentication.h in Headers */ = {isa = PBXBuildFile; fileRef = A998248F17CAA39200646828 /* BARBasicAuthentication.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A998249217CAA39200646828 /* BARBasicAuthentication.m in Sources */ = {isa = PBXBuildFile; fileRef = A998249017CAA39200646828 /* BARBasicAuthentication.m */; };
+		A998249517CABAD600646828 /* NSData+Base64.h in Headers */ = {isa = PBXBuildFile; fileRef = A998249317CABAD500646828 /* NSData+Base64.h */; };
+		A998249617CABAD600646828 /* NSData+Base64.m in Sources */ = {isa = PBXBuildFile; fileRef = A998249417CABAD600646828 /* NSData+Base64.m */; };
 		F524B3B78FCC4D2085BE380A /* libPods.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 52E44A98267A45BEB8E01B9F /* libPods.a */; };
 /* End PBXBuildFile section */
 
@@ -159,6 +163,10 @@
 		1E5DFA7D172F82EA00FB6CD1 /* BARTemplateRenderer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BARTemplateRenderer.h; sourceTree = "<group>"; };
 		1E5DFA7E172F82EA00FB6CD1 /* BARTemplateRenderer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BARTemplateRenderer.m; sourceTree = "<group>"; };
 		52E44A98267A45BEB8E01B9F /* libPods.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libPods.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		A998248F17CAA39200646828 /* BARBasicAuthentication.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BARBasicAuthentication.h; path = Authentication/BARBasicAuthentication.h; sourceTree = "<group>"; };
+		A998249017CAA39200646828 /* BARBasicAuthentication.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BARBasicAuthentication.m; path = Authentication/BARBasicAuthentication.m; sourceTree = "<group>"; };
+		A998249317CABAD500646828 /* NSData+Base64.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSData+Base64.h"; sourceTree = "<group>"; };
+		A998249417CABAD600646828 /* NSData+Base64.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSData+Base64.m"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -331,6 +339,7 @@
 				1E5DFA5E172DFF2900FB6CD1 /* Cookies */,
 				1E5DFA52172DE7BE00FB6CD1 /* Sessions */,
 				1E5DFA76172F818600FB6CD1 /* Templates */,
+				A998249717CABDB100646828 /* Authentication */,
 			);
 			path = Middleware;
 			sourceTree = "<group>";
@@ -385,6 +394,8 @@
 		1E5DFA6C172E432200FB6CD1 /* Categories */ = {
 			isa = PBXGroup;
 			children = (
+				A998249317CABAD500646828 /* NSData+Base64.h */,
+				A998249417CABAD600646828 /* NSData+Base64.m */,
 				1E5DFA6D172E433B00FB6CD1 /* NSData+BaristaExtensions.h */,
 				1E5DFA6E172E433B00FB6CD1 /* NSData+BaristaExtensions.m */,
 			);
@@ -419,6 +430,15 @@
 			path = Mustache;
 			sourceTree = "<group>";
 		};
+		A998249717CABDB100646828 /* Authentication */ = {
+			isa = PBXGroup;
+			children = (
+				A998248F17CAA39200646828 /* BARBasicAuthentication.h */,
+				A998249017CAA39200646828 /* BARBasicAuthentication.m */,
+			);
+			name = Authentication;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
@@ -443,6 +463,8 @@
 				1E3B29C7172F993500D9833A /* BARStaticFileServer.h in Headers */,
 				1E5DFA7B172F81F300FB6CD1 /* BARMustacheTemplateRenderer.h in Headers */,
 				1E5DFA7F172F82EA00FB6CD1 /* BARTemplateRenderer.h in Headers */,
+				A998249117CAA39200646828 /* BARBasicAuthentication.h in Headers */,
+				A998249517CABAD600646828 /* NSData+Base64.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -639,6 +661,8 @@
 				1E5DFA7C172F81F300FB6CD1 /* BARMustacheTemplateRenderer.m in Sources */,
 				1E5DFA80172F82EA00FB6CD1 /* BARTemplateRenderer.m in Sources */,
 				1E3B29C8172F993500D9833A /* BARStaticFileServer.m in Sources */,
+				A998249217CAA39200646828 /* BARBasicAuthentication.m in Sources */,
+				A998249617CABAD600646828 /* NSData+Base64.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Barista/Categories/NSData+BaristaExtensions.h
+++ b/Barista/Categories/NSData+BaristaExtensions.h
@@ -7,6 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
+#import "NSData+Base64.h"
 
 @interface NSData (BaristaExtensions)
 

--- a/Barista/Categories/NSData+Base64.h
+++ b/Barista/Categories/NSData+Base64.h
@@ -1,0 +1,47 @@
+//
+//  NSData+Base64.h
+//  base64
+//
+//  Created by Matt Gallagher on 2009/06/03.
+//  Copyright 2009 Matt Gallagher. All rights reserved.
+//
+//  This software is provided 'as-is', without any express or implied
+//  warranty. In no event will the authors be held liable for any damages
+//  arising from the use of this software. Permission is granted to anyone to
+//  use this software for any purpose, including commercial applications, and to
+//  alter it and redistribute it freely, subject to the following restrictions:
+//
+//  1. The origin of this software must not be misrepresented; you must not
+//     claim that you wrote the original software. If you use this software
+//     in a product, an acknowledgment in the product documentation would be
+//     appreciated but is not required.
+//  2. Altered source versions must be plainly marked as such, and must not be
+//     misrepresented as being the original software.
+//  3. This notice may not be removed or altered from any source
+//     distribution.
+//
+
+// Modifications for the Barista project:
+// - Methods prefixed with 'barista_'
+// - -[NSData barista_base64DecodedString] method added.
+
+#import <Foundation/Foundation.h>
+
+void *NewBase64Decode(
+	const char *inputBuffer,
+	size_t length,
+	size_t *outputLength);
+
+char *NewBase64Encode(
+	const void *inputBuffer,
+	size_t length,
+	bool separateLines,
+	size_t *outputLength);
+
+@interface NSData (Base64)
+
++ (NSData *)barista_dataFromBase64String:(NSString *)aString;
+- (NSString *)barista_base64DecodedString;
+- (NSString *)barista_base64EncodedString;
+
+@end

--- a/Barista/Categories/NSData+Base64.m
+++ b/Barista/Categories/NSData+Base64.m
@@ -1,0 +1,322 @@
+//
+//  NSData+Base64.m
+//  base64
+//
+//  Created by Matt Gallagher on 2009/06/03.
+//  Copyright 2009 Matt Gallagher. All rights reserved.
+//
+//  This software is provided 'as-is', without any express or implied
+//  warranty. In no event will the authors be held liable for any damages
+//  arising from the use of this software. Permission is granted to anyone to
+//  use this software for any purpose, including commercial applications, and to
+//  alter it and redistribute it freely, subject to the following restrictions:
+//
+//  1. The origin of this software must not be misrepresented; you must not
+//     claim that you wrote the original software. If you use this software
+//     in a product, an acknowledgment in the product documentation would be
+//     appreciated but is not required.
+//  2. Altered source versions must be plainly marked as such, and must not be
+//     misrepresented as being the original software.
+//  3. This notice may not be removed or altered from any source
+//     distribution.
+//
+
+#import "NSData+Base64.h"
+
+//
+// Mapping from 6 bit pattern to ASCII character.
+//
+static unsigned char base64EncodeLookup[65] =
+	"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+//
+// Definition for "masked-out" areas of the base64DecodeLookup mapping
+//
+#define xx 65
+
+//
+// Mapping from ASCII character to 6 bit pattern.
+//
+static unsigned char base64DecodeLookup[256] =
+{
+    xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, 
+    xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, 
+    xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, 62, xx, xx, xx, 63, 
+    52, 53, 54, 55, 56, 57, 58, 59, 60, 61, xx, xx, xx, xx, xx, xx, 
+    xx,  0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 
+    15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, xx, xx, xx, xx, xx, 
+    xx, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 
+    41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, xx, xx, xx, xx, xx, 
+    xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, 
+    xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, 
+    xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, 
+    xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, 
+    xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, 
+    xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, 
+    xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, 
+    xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, 
+};
+
+//
+// Fundamental sizes of the binary and base64 encode/decode units in bytes
+//
+#define BINARY_UNIT_SIZE 3
+#define BASE64_UNIT_SIZE 4
+
+//
+// NewBase64Decode
+//
+// Decodes the base64 ASCII string in the inputBuffer to a newly malloced
+// output buffer.
+//
+//  inputBuffer - the source ASCII string for the decode
+//	length - the length of the string or -1 (to specify strlen should be used)
+//	outputLength - if not-NULL, on output will contain the decoded length
+//
+// returns the decoded buffer. Must be free'd by caller. Length is given by
+//	outputLength.
+//
+void *NewBase64Decode(
+	const char *inputBuffer,
+	size_t length,
+	size_t *outputLength)
+{
+	if (length == -1)
+	{
+		length = strlen(inputBuffer);
+	}
+	
+	size_t outputBufferSize =
+		((length+BASE64_UNIT_SIZE-1) / BASE64_UNIT_SIZE) * BINARY_UNIT_SIZE;
+	unsigned char *outputBuffer = (unsigned char *)malloc(outputBufferSize);
+	
+	size_t i = 0;
+	size_t j = 0;
+	while (i < length)
+	{
+		//
+		// Accumulate 4 valid characters (ignore everything else)
+		//
+		unsigned char accumulated[BASE64_UNIT_SIZE];
+		size_t accumulateIndex = 0;
+		while (i < length)
+		{
+			unsigned char decode = base64DecodeLookup[inputBuffer[i++]];
+			if (decode != xx)
+			{
+				accumulated[accumulateIndex] = decode;
+				accumulateIndex++;
+				
+				if (accumulateIndex == BASE64_UNIT_SIZE)
+				{
+					break;
+				}
+			}
+		}
+		
+		//
+		// Store the 6 bits from each of the 4 characters as 3 bytes
+		//
+		// (Uses improved bounds checking suggested by Alexandre Colucci)
+		//
+		if(accumulateIndex >= 2)  
+			outputBuffer[j] = (accumulated[0] << 2) | (accumulated[1] >> 4);  
+		if(accumulateIndex >= 3)  
+			outputBuffer[j + 1] = (accumulated[1] << 4) | (accumulated[2] >> 2);  
+		if(accumulateIndex >= 4)  
+			outputBuffer[j + 2] = (accumulated[2] << 6) | accumulated[3];
+		j += accumulateIndex - 1;
+	}
+	
+	if (outputLength)
+	{
+		*outputLength = j;
+	}
+	return outputBuffer;
+}
+
+//
+// NewBase64Encode
+//
+// Encodes the arbitrary data in the inputBuffer as base64 into a newly malloced
+// output buffer.
+//
+//  inputBuffer - the source data for the encode
+//	length - the length of the input in bytes
+//  separateLines - if zero, no CR/LF characters will be added. Otherwise
+//		a CR/LF pair will be added every 64 encoded chars.
+//	outputLength - if not-NULL, on output will contain the encoded length
+//		(not including terminating 0 char)
+//
+// returns the encoded buffer. Must be free'd by caller. Length is given by
+//	outputLength.
+//
+char *NewBase64Encode(
+	const void *buffer,
+	size_t length,
+	bool separateLines,
+	size_t *outputLength)
+{
+	const unsigned char *inputBuffer = (const unsigned char *)buffer;
+	
+	#define MAX_NUM_PADDING_CHARS 2
+	#define OUTPUT_LINE_LENGTH 64
+	#define INPUT_LINE_LENGTH ((OUTPUT_LINE_LENGTH / BASE64_UNIT_SIZE) * BINARY_UNIT_SIZE)
+	#define CR_LF_SIZE 2
+	
+	//
+	// Byte accurate calculation of final buffer size
+	//
+	size_t outputBufferSize =
+			((length / BINARY_UNIT_SIZE)
+				+ ((length % BINARY_UNIT_SIZE) ? 1 : 0))
+					* BASE64_UNIT_SIZE;
+	if (separateLines)
+	{
+		outputBufferSize +=
+			(outputBufferSize / OUTPUT_LINE_LENGTH) * CR_LF_SIZE;
+	}
+	
+	//
+	// Include space for a terminating zero
+	//
+	outputBufferSize += 1;
+
+	//
+	// Allocate the output buffer
+	//
+	char *outputBuffer = (char *)malloc(outputBufferSize);
+	if (!outputBuffer)
+	{
+		return NULL;
+	}
+
+	size_t i = 0;
+	size_t j = 0;
+	const size_t lineLength = separateLines ? INPUT_LINE_LENGTH : length;
+	size_t lineEnd = lineLength;
+	
+	while (true)
+	{
+		if (lineEnd > length)
+		{
+			lineEnd = length;
+		}
+
+		for (; i + BINARY_UNIT_SIZE - 1 < lineEnd; i += BINARY_UNIT_SIZE)
+		{
+			//
+			// Inner loop: turn 48 bytes into 64 base64 characters
+			//
+			outputBuffer[j++] = base64EncodeLookup[(inputBuffer[i] & 0xFC) >> 2];
+			outputBuffer[j++] = base64EncodeLookup[((inputBuffer[i] & 0x03) << 4)
+				| ((inputBuffer[i + 1] & 0xF0) >> 4)];
+			outputBuffer[j++] = base64EncodeLookup[((inputBuffer[i + 1] & 0x0F) << 2)
+				| ((inputBuffer[i + 2] & 0xC0) >> 6)];
+			outputBuffer[j++] = base64EncodeLookup[inputBuffer[i + 2] & 0x3F];
+		}
+		
+		if (lineEnd == length)
+		{
+			break;
+		}
+		
+		//
+		// Add the newline
+		//
+		outputBuffer[j++] = '\r';
+		outputBuffer[j++] = '\n';
+		lineEnd += lineLength;
+	}
+	
+	if (i + 1 < length)
+	{
+		//
+		// Handle the single '=' case
+		//
+		outputBuffer[j++] = base64EncodeLookup[(inputBuffer[i] & 0xFC) >> 2];
+		outputBuffer[j++] = base64EncodeLookup[((inputBuffer[i] & 0x03) << 4)
+			| ((inputBuffer[i + 1] & 0xF0) >> 4)];
+		outputBuffer[j++] = base64EncodeLookup[(inputBuffer[i + 1] & 0x0F) << 2];
+		outputBuffer[j++] =	'=';
+	}
+	else if (i < length)
+	{
+		//
+		// Handle the double '=' case
+		//
+		outputBuffer[j++] = base64EncodeLookup[(inputBuffer[i] & 0xFC) >> 2];
+		outputBuffer[j++] = base64EncodeLookup[(inputBuffer[i] & 0x03) << 4];
+		outputBuffer[j++] = '=';
+		outputBuffer[j++] = '=';
+	}
+	outputBuffer[j] = 0;
+	
+	//
+	// Set the output length and return the buffer
+	//
+	if (outputLength)
+	{
+		*outputLength = j;
+	}
+	return outputBuffer;
+}
+
+@implementation NSData (Base64)
+
+//
+// dataFromBase64String:
+//
+// Creates an NSData object containing the base64 decoded representation of
+// the base64 string 'aString'
+//
+// Parameters:
+//    aString - the base64 string to decode
+//
+// returns the autoreleased NSData representation of the base64 string
+//
++ (NSData *)barista_dataFromBase64String:(NSString *)aString
+{
+	NSData *data = [aString dataUsingEncoding:NSASCIIStringEncoding];
+	size_t outputLength;
+	void *outputBuffer = NewBase64Decode([data bytes], [data length], &outputLength);
+	NSData *result = [NSData dataWithBytes:outputBuffer length:outputLength];
+	free(outputBuffer);
+	return result;
+}
+
+
+- (NSString *)barista_base64DecodedString {
+	size_t outputLength;
+	char *outputBuffer = NewBase64Decode([self bytes], [self length], &outputLength);
+
+	NSString *result = [[NSString alloc] initWithBytes:outputBuffer length:outputLength encoding:NSASCIIStringEncoding];
+	free(outputBuffer);
+	return result;
+}
+
+//
+// base64EncodedString
+//
+// Creates an NSString object that contains the base 64 encoding of the
+// receiver's data. Lines are broken at 64 characters long.
+//
+// returns an autoreleased NSString being the base 64 representation of the
+//	receiver.
+//
+- (NSString *)barista_base64EncodedString
+{
+	size_t outputLength;
+	char *outputBuffer =
+		NewBase64Encode([self bytes], [self length], true, &outputLength);
+	
+	NSString *result =
+		[[NSString alloc]
+			initWithBytes:outputBuffer
+			length:outputLength
+			encoding:NSASCIIStringEncoding];
+	free(outputBuffer);
+	return result;
+}
+
+@end

--- a/Barista/Middleware/Authentication/BARBasicAuthentication.h
+++ b/Barista/Middleware/Authentication/BARBasicAuthentication.h
@@ -1,0 +1,40 @@
+//
+//  BARBasicAuthentication.h
+//  Barista
+//
+//  Created by Teapot on 8/25/13.
+//  Copyright (c) 2013 Mustacheware. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import "BaristaTypes.h"
+#import "BARRequest.h"
+#import "BARResponse.h"
+#import "NSData+BaristaExtensions.h"
+
+/**
+ A block that checks an NSURLCredential's validity.
+ @param credential The credential to check.
+ @return A boolean value indicating whether the presented credential should be authorized.
+ */
+typedef BOOL (^BARBasicAuthenticationBlock)(NSURLCredential *credential);
+
+
+/**
+ `BARBasicAuthentication` is a Barista middleware class for requiring HTTP Basic authentication on the requests it processes.
+ */
+@interface BARBasicAuthentication : NSObject <BaristaMiddleware>
+/** The realm to show to the user when an authentication challenge is presented. */
+@property (copy, nonatomic) NSString *realm;
+
+/** The block used to check validity of a presented credential. */
+@property (copy, nonatomic) BARBasicAuthenticationBlock authorizationBlock;
+
+/**
+ Initializes the receiver with a realm and authorization block.
+ @param realm The realm to show to the user when an authentication challenge is presented.
+ @param authorizationBlock The block used to check validity of a presented credential.
+ @return The initialized middleware.
+ */
+- (instancetype)initWithRealm:(NSString *)realm authorizationBlock:(BARBasicAuthenticationBlock)authorizationBlock;
+@end

--- a/Barista/Middleware/Authentication/BARBasicAuthentication.m
+++ b/Barista/Middleware/Authentication/BARBasicAuthentication.m
@@ -1,0 +1,104 @@
+//
+//  BARBasicAuthentication.m
+//  Barista
+//
+//  Created by Bill Williams on 8/25/13.
+//  Copyright (c) 2013 Steve Streza. All rights reserved.
+//
+
+#import "BARBasicAuthentication.h"
+
+@interface BARBasicAuthentication ()
+/**
+ Generates and returns an NSURLCredential for basic authentication from the value of an HTTP Authorization field.
+ @param fieldValue The value of an HTTP Authorization field.
+ @return An NSURLCredential with username and password, if the field contained a valid credential. If no credential was found, nil.
+ */
+- (NSURLCredential *)credentialFromAuthorizationField:(NSString *)fieldValue;
+
+/**
+ Generates and returns an NSURLCredential for basic authentication from the user and value segments of an NSURL.
+ @param URL The URL from which to use the username and password.
+ @return An NSURLCredential with the username and password from the URL.
+ @discussion This method uses NSURL’s -user and -password methods to parse the username and password values.
+ */
+- (NSURLCredential *)credentialFromURL:(NSURL *)URL;
+@end
+
+
+@implementation BARBasicAuthentication
+
+- (instancetype)initWithRealm:(NSString *)realm authorizationBlock:(BARBasicAuthenticationBlock)authorizationBlock {
+	self = [super init];
+	if (self) {
+		self.realm = realm;
+		self.authorizationBlock = authorizationBlock;
+	}
+	return self;
+}
+
+
+#pragma mark - Barista Middleware
+- (void)willSendResponse:(BARResponse *)response forRequest:(BARRequest *)request forConnection:(BARConnection *)connection continueHandler:(void (^)(void))handler {
+
+	// Presume that we're unauthorized by default
+	BOOL authorized = NO;
+	NSURLCredential *credential = nil;
+
+	// Attempt to parse a credential from the Authorization header
+	credential = [self credentialFromAuthorizationField:request.headerFields[@"Authorization"]];
+
+	// Attempt to parse a credential from the URL
+	if (!credential) {
+		credential = [self credentialFromURL:request.URL];
+	}
+
+	// Ask the authorization block if the credential is valid
+	if (credential && self.authorizationBlock) {
+		authorized = self.authorizationBlock(credential);
+	}
+
+	// If we're still not authorized, challenge the client for credentials
+	if (!authorized) {
+		// Send the authentication challenge
+		NSString *authenticateHeader = [NSString stringWithFormat:@"Basic realm=\"%@\"", self.realm];
+		[response setValue:authenticateHeader forHTTPHeaderField:@"WWW-Authenticate"];
+		response.statusCode = 401;
+	}
+
+	// Continue processing the request
+	handler();
+}
+
+
+#pragma mark - Private methods
+- (NSURLCredential *)credentialFromAuthorizationField:(NSString *)fieldValue {
+	NSArray *headerComponents = [fieldValue componentsSeparatedByString:@" "];
+
+	// Make sure this is an HTTP Basic authorization header
+	if (![[headerComponents[0] lowercaseString] isEqualToString:@"basic"]) {
+		return nil;
+	}
+
+	// Base64 decode the authorization value
+	NSString *foo = headerComponents[1];
+	NSData *data = [foo dataUsingEncoding:NSASCIIStringEncoding];
+	NSString *baz = [data barista_base64DecodedString];
+
+	NSArray *authComponents = [baz componentsSeparatedByString:@":"];
+	NSString *username = authComponents[0];
+	NSString *password = authComponents[1];
+
+	// Create and return the credential
+	NSURLCredential *credential = [[NSURLCredential alloc] initWithUser:username password:password persistence:NSURLCredentialPersistenceNone];
+	return credential;
+}
+
+
+- (NSURLCredential *)credentialFromURL:(NSURL *)URL {
+	// Create and return a credential from the URL value
+	NSURLCredential *credential = [[NSURLCredential alloc] initWithUser:[URL user] password:[URL password] persistence:NSURLCredentialPersistenceNone];
+	return credential;
+}
+
+@end

--- a/BaristaDemo/BARDemoServer.h
+++ b/BaristaDemo/BARDemoServer.h
@@ -34,6 +34,7 @@
 #import <Barista/BARBodyParser.h>
 #import <Barista/BARMustacheTemplateRenderer.h>
 #import <Barista/BARStaticFileServer.h>
+#import <Barista/BARBasicAuthentication.h>
 
 @interface BARDemoServer : BARServer
 

--- a/BaristaDemo/BARDemoServer.m
+++ b/BaristaDemo/BARDemoServer.m
@@ -40,6 +40,12 @@
 															   forURLBasePath:@"/public/"]];
 	[self addGlobalMiddleware:[[BARBodyParser alloc] init]];
 	[self addGlobalMiddleware:[BARMustacheTemplateRenderer rendererWithViewsDirectoryURL:[webAppURL URLByAppendingPathComponent:@"views"]]];
+	[self addGlobalMiddleware:[[BARBasicAuthentication alloc] initWithRealm:@"unicorn / rainbows" authorizationBlock:^BOOL(NSURLCredential *credential) {
+		BOOL authorized = YES;
+		authorized &= [credential.user isEqualToString:@"unicorn"];
+		authorized &= [credential.password isEqualToString:@"rainbows"];
+		return authorized;
+	}]];
 	
 	[self addRoute:@"/foo/:bar" forHTTPMethod:@"GET" handler:^BOOL(BARConnection *connection, BARRequest *request, NSDictionary *parameters) {
 		NSLog(@"/foo/:bar parameters: %@", parameters);


### PR DESCRIPTION
This is a pretty basic implementation. (Pun not intended.)

``` objc
[self addGlobalMiddleware:[[BARBasicAuthentication alloc] initWithRealm:@"unicorn / rainbows" authorizationBlock:^BOOL(NSURLCredential *credential) {
    BOOL authorized = YES;
    authorized &= [credential.user isEqualToString:@"unicorn"];
    authorized &= [credential.password isEqualToString:@"rainbows"];
    return authorized;
}]];
```

I pulled in Matt Gallager’s iOS-friendly implementation of Base64 encoding/decoding for this; please let me know if there’s a better pre-10.9/iOS 7 solution you’d like to use.
